### PR TITLE
Allow lib users to override the HttpClient class

### DIFF
--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface as SymfonyHttpClientInterface;
 
-final class HttpClient implements HttpClientInterface
+class HttpClient implements HttpClientInterface
 {
     private SymfonyHttpClientInterface $client;
     private string $endpoint;


### PR DESCRIPTION
I need to log my API calls, for this I'd love to be able to override the HttpClient:: request method, but I'm not able because of the `final`. Can you consider to remove it?