### PR TITLE
[SW] - added functionality to handle API requests with commands

### DIFF
--- a/src/Api/Commands.php
+++ b/src/Api/Commands.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Oveleon\YouTrack\Api;
+
+class Commands extends AbstractApi
+{
+
+    public function command($parameters)
+    {
+        $this->addFields(
+            []
+        );
+        return $this->post("commands", $parameters);
+    }
+}

--- a/src/Api/Commands.php
+++ b/src/Api/Commands.php
@@ -4,12 +4,19 @@ namespace Oveleon\YouTrack\Api;
 
 class Commands extends AbstractApi
 {
-
-    public function command($parameters)
+    protected function defaultFields(): self
     {
-        $this->addFields(
-            []
-        );
+        $this->addFields([
+            'id',
+            'idReadable',
+            'summary'
+        ]);
+
+        return $this;
+    }
+
+    public function command($parameters): array
+    {
         return $this->post("commands", $parameters);
     }
 }

--- a/src/Api/Issue.php
+++ b/src/Api/Issue.php
@@ -153,9 +153,4 @@ class Issue extends AbstractApi
     {
         return new TimeTracking($this->getClient());
     }
-
-    public function command($parameters)
-    {
-        return $this->post("commands", $parameters);
-    }
 }

--- a/src/Api/Issue.php
+++ b/src/Api/Issue.php
@@ -153,4 +153,9 @@ class Issue extends AbstractApi
     {
         return new TimeTracking($this->getClient());
     }
+
+    public function command($parameters)
+    {
+        return $this->post("commands", $parameters);
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ namespace Oveleon\YouTrack;
 
 use Oveleon\YouTrack\Api\Issue;
 use Oveleon\YouTrack\Api\Project;
+use Oveleon\YouTrack\Api\Commands;
 use Oveleon\YouTrack\Api\User;
 use Oveleon\YouTrack\Api\WorkItem;
 use Oveleon\YouTrack\HttpClient\HttpClientInterface;
@@ -28,6 +29,11 @@ class Client
     public function issues(): Issue
     {
         return new Issue($this);
+    }
+
+    public function commands(): Commands
+    {
+        return new Commands($this);
     }
 
     public function projects(): Project

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface as SymfonyHttpClientInterface;
 
-class HttpClient implements HttpClientInterface
+final class HttpClient implements HttpClientInterface
 {
     private SymfonyHttpClientInterface $client;
     private string $endpoint;


### PR DESCRIPTION
This part is required to be able to assign tasks to agile boards and related Swimlanes 


       ``` 
       $setSubTask = [
            'query' => 'subtask of {idReadable}',
            'issues'=> [
                ['idReadable' => 'TEST-1']
            ]
        ];
        
        $assignToBoard = [
            'query' => 'add Board {board name}',
            'issues'=> [
                ['idReadable' => 'TEST-1']
            ]
        ];
        
        $api->commands()->command($setSubTask);
        $api->commands()->command($assignToBoard);```