### PR TITLE
Add support for symfony components 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "homepage": "https://www.oveleon.de",
     "require": {
         "php": ">=8.1",
-        "symfony/http-foundation": "^5.0|^6.0",
-        "symfony/http-client": "^5.0|^6.0"
+        "symfony/http-foundation": "^5.0|^6.0|^7.0",
+        "symfony/http-client": "^5.0|^6.0|^7.0"
     },
     "require-dev": {},
     "conflict": {},


### PR DESCRIPTION
This library currently doesn't support symfony 7.x. Just changing composer version seems to be enough regarding the current implementation with an custom HttpClient class.